### PR TITLE
Retain constness of parameters.

### DIFF
--- a/grub-core/disk/cryptodisk.c
+++ b/grub-core/disk/cryptodisk.c
@@ -114,7 +114,7 @@ gf_mul_be (grub_uint8_t *o, const grub_uint8_t *a, const grub_uint8_t *b)
 }
 
 int
-grub_cryptodisk_uuidcmp(char *uuid_a, char *uuid_b)
+grub_cryptodisk_uuidcmp(const char *uuid_a, const char *uuid_b)
 {
   while ((*uuid_a != '\0') && (*uuid_b != '\0'))
     {

--- a/include/grub/cryptodisk.h
+++ b/include/grub/cryptodisk.h
@@ -168,5 +168,5 @@ grub_cryptodisk_t grub_cryptodisk_create (grub_disk_t disk, char *uuid,
 				   char *ciphername, char *ciphermode, char *digest);
 
 int
-grub_cryptodisk_uuidcmp(char *uuid_a, char *uuid_b);
+grub_cryptodisk_uuidcmp(const char *uuid_a, const char *uuid_b);
 #endif


### PR DESCRIPTION
Don't drop constness on the parameters since they are being only read anyway. Without this patch, compilation fails for me since the compiler complains that the constness of passed in parameters is being dropped.
