### PR TITLE
Add support for using a whole device as a keyfile

### DIFF
--- a/grub-core/disk/cryptodisk.c
+++ b/grub-core/disk/cryptodisk.c
@@ -1031,26 +1031,76 @@ grub_cmd_cryptomount (grub_extcmd_context_t ctxt, int argc, char **args)
       else
         {
           keyfile_offset = state[5].set ? grub_strtoul (state[5].arg, 0, 0) : 0;
-          keyfile_size = requested_keyfile_size ? requested_keyfile_size : \
-		                             GRUB_CRYPTODISK_MAX_KEYFILE_SIZE;
 
-          keyfile = grub_file_open (state[4].arg);
-          if (!keyfile)
-            grub_printf (N_("Unable to open key file %s\n"), state[4].arg);
-          else if (grub_file_seek (keyfile, keyfile_offset) == (grub_off_t)-1)
-            grub_printf (N_("Unable to seek to offset %d in key file\n"), keyfile_offset);
+          if (grub_strchr (state[4].arg, '/'))
+            {
+              keyfile_size = requested_keyfile_size ? requested_keyfile_size : \
+                                                 GRUB_CRYPTODISK_MAX_KEYFILE_SIZE;
+              keyfile = grub_file_open (state[4].arg);
+              if (!keyfile)
+                grub_printf (N_("Unable to open key file %s\n"), state[4].arg);
+              else if (grub_file_seek (keyfile, keyfile_offset) == (grub_off_t)-1)
+                grub_printf (N_("Unable to seek to offset %d in key file\n"), keyfile_offset);
+              else
+                {
+                  keyfile_size = grub_file_read (keyfile, keyfile_buffer, keyfile_size);
+                  if (keyfile_size == (grub_size_t)-1)
+                     grub_printf (N_("Error reading key file\n"));
+                  else if (requested_keyfile_size && (keyfile_size != requested_keyfile_size))
+                     grub_printf (N_("Cannot read %llu bytes for key file (read %llu bytes)\n"),
+                                                    (unsigned long long) requested_keyfile_size,
+                                                    (unsigned long long) keyfile_size);
+                  else
+                    key = keyfile_buffer;
+                }
+            }
           else
             {
-              keyfile_size = grub_file_read (keyfile, keyfile_buffer, keyfile_size);
-              if (keyfile_size == (grub_size_t)-1)
-                 grub_printf (N_("Error reading key file\n"));
-	      else if (requested_keyfile_size && (keyfile_size != requested_keyfile_size))
-                 grub_printf (N_("Cannot read %llu bytes for key file (read %llu bytes)\n"),
-                                                (unsigned long long) requested_keyfile_size,
-						(unsigned long long) keyfile_size);
-              else
-                key = keyfile_buffer;
-	    }
+              grub_disk_t keydisk;
+              char* keydisk_name;
+              grub_err_t err;
+              grub_uint64_t total_sectors;
+
+              keydisk_name = grub_file_get_device_name(state[4].arg);
+              keydisk = grub_disk_open (keydisk_name);
+              if (!keydisk)
+                {
+                  grub_printf (N_("Unable to open disk %s\n"), keydisk_name);
+                  goto cleanup_keydisk_name;
+                }
+
+              total_sectors = grub_disk_get_size (keydisk);
+              if (total_sectors == GRUB_DISK_SIZE_UNKNOWN)
+                {
+                  grub_printf (N_("Unable to determine size of disk %s\n"), keydisk_name);
+                  goto cleanup_keydisk;
+                }
+
+              keyfile_size = (total_sectors << GRUB_DISK_SECTOR_BITS);
+              if (requested_keyfile_size > 0 && requested_keyfile_size < keyfile_size)
+                keyfile_size = requested_keyfile_size;
+              if (keyfile_size > GRUB_CRYPTODISK_MAX_KEYFILE_SIZE)
+                {
+                  grub_printf (N_("Key file size exceeds maximum (%llu)\n"), \
+                               (unsigned long long) GRUB_CRYPTODISK_MAX_KEYFILE_SIZE);
+                  goto cleanup_keydisk;
+                }
+
+              err = grub_disk_read (keydisk, 0, keyfile_offset, keyfile_size, keyfile_buffer);
+              if (err != GRUB_ERR_NONE)
+                {
+                  grub_printf (N_("Failed to read from disk %s\n"), keydisk_name);
+                  keyfile_size = 0;
+                  goto cleanup_keydisk;
+                }
+
+              key = keyfile_buffer;
+
+              cleanup_keydisk:
+              grub_disk_close (keydisk);
+              cleanup_keydisk_name:
+              grub_free (keydisk_name);
+            }
         }
     }
 


### PR DESCRIPTION
OK, this is what I have to solve #7. It fixes the situation where a device is passed as a parameter to `--keyfile` instead of the path to a file. For instance:

```
cryptomount (hd1,gpt2) -k (crypto0)
```

This can be used to offer two-factor authentication by first unlocking a LUKS container using a passphrase, then using the content of the unlocked container as a keyfile for the boot partition.

The `--keyfile-offset` and `--keyfile-size` parameters work with this option in the same way as for a regular keyfile.

One thing I've noticed: I seem unable to get the correct size of the key-device when it's a crypto device. I think this may be a bug in the `luks` module, but I haven't been able to track it down. The device size is correctly detected for a physical disk (e.g hd1,gpt2), but I get 2057 instead of 1 returned by `grub_disk_get_size (keydisk)` when using `crypt0` as a key device. I can work around this easily in practice by providing the keyfile size as a parameter, but it's still unfortunate. I've spent quite some time trying to figure out what I might be missing with the size calculation, but for now I'm stumped. Incidentally, the size is returned correctly when using an older version of `luks.module`, but then the keyfile unlocking doesn't work :D
